### PR TITLE
Fix the rendering of effective date.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Fix: try to get the value of a method if the field is a method and translate
+  DateTime results to a unicode, this fixes the export for objects with the IPublication
+  Behavior.
+  [pcdummy]
+
 - Fix: be sure to not retrieve an attribute on an object by acquisition.
   [vincentfretin]
 

--- a/src/collective/excelexport/exportables/dexterityfields.py
+++ b/src/collective/excelexport/exportables/dexterityfields.py
@@ -152,7 +152,10 @@ class DexterityValueGetter(object):
         self.context = context
 
     def get(self, field):
-        return getattr(aq_base(self.context), field.__name__, None)
+        value = getattr(aq_base(self.context), field.__name__, None)
+        if hasattr(value, '__call__'):
+            value = value()
+        return value
 
 
 class BaseFieldRenderer(object):

--- a/src/collective/excelexport/view.py
+++ b/src/collective/excelexport/view.py
@@ -5,6 +5,7 @@ from StringIO import StringIO
 import xlwt
 from xlwt import CompoundDoc
 
+from DateTime import DateTime
 from zope.component import getMultiAdapter
 from zope.component.interfaces import ComponentLookupError
 from zope.i18n import translate
@@ -46,6 +47,8 @@ class ExcelExport(BaseExport):
             render = translate(render, context=self.request)
         elif isinstance(render, str):
             render = unicode(render)
+        elif isinstance(render, DateTime):
+            render = unicode(render.strftime("%Y/%m/%d"))
 
         return render
 


### PR DESCRIPTION
Try to get the value of a method if the field is a method and translate
DateTime results to a unicode, this fixes the export for objects with the IPublication behavior.

Signed-off-by: Rene Jochum rene@jochums.at
