### PR TITLE
check if value_type is empty for collection field render

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.3 (unreleased)
 ----------------
 
+- Fix: check if value_type is empty for collection field render.
+  [bsuttor]
+
 - Fix: try to get the value of a method if the field is a method and translate
   DateTime results to a unicode, this fixes the export for objects with the IPublication
   Behavior.

--- a/src/collective/excelexport/exportables/dexterityfields.py
+++ b/src/collective/excelexport/exportables/dexterityfields.py
@@ -286,9 +286,14 @@ class CollectionFieldRenderer(BaseFieldRenderer):
         """Gets the value to render in excel file from content value
         """
         value = self.get_value(obj)
+        value_type = self.field.value_type
+        if not value_type:
+            value_type = self.field
+
         sub_renderer = getMultiAdapter(
-            (self.field.value_type, self.context, self.request),
+            (value_type, self.context, self.request),
             interface=IExportable)
+
         return value and self.separator.join(
             [sub_renderer.render_collection_entry(obj, v)
              for v in value]) or u""


### PR DESCRIPTION
With dexterity and faceted nav, I had a error because `self.field.value_type` was empty value and I was not able to call getMultiAdapter

```

2016-11-21 09:43:08 ERROR Zope.SiteErrorLog 1479717788.240.436938324852 http://localhost:8080/plone/@@collective.excelexport
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module Products.PDBDebugMode.runcall, line 70, in pdb_runcall
  Module ZPublisher.Publish, line 48, in call_object
  Module collective.excelexport.view, line 120, in __call__
  Module collective.excelexport.view, line 94, in get_xldoc
  Module collective.excelexport.view, line 73, in write_sheet
  Module collective.excelexport.exportables.dexterityfields, line 291, in render_value
  Module zope.component._api, line 109, in getMultiAdapter
ComponentLookupError: ((None, <PloneSite at /plone>, <HTTPRequest, URL=http://localhost:8080/plone/@@collective.excelexport>), <InterfaceClass collective.excelexport.interfaces.IExportable>, u'')
```
