### PR TITLE
Correctly export integer as number for excel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
+- Correctly export integer as number for excel.
+  [Gagaro]
+
 - Added Transifex.net service integration to manage the translation process.
   [macagua]
 

--- a/src/collective/excelexport/exportables/dexterityfields.py
+++ b/src/collective/excelexport/exportables/dexterityfields.py
@@ -355,6 +355,9 @@ class TextFieldRenderer(BaseFieldRenderer):
             return ""
 
         text = safe_unicode(self._get_text(value))
+        if not isinstance(text, unicode):
+            return text
+
         if len(text) > self.truncate_at + 3:
             return text[:self.truncate_at] + u"..."
 

--- a/src/collective/excelexport/view.py
+++ b/src/collective/excelexport/view.py
@@ -80,6 +80,11 @@ class ExcelExport(BaseExport):
     mimetype = "application/vnd.ms-excel"
     extension = "xls"
     encoding = "windows-1252"
+    
+    def _format_render(self, render):
+        if isinstance(render, int):
+            return render
+        return super(ExcelExport, self)._format_render(render)
 
     def write_sheet(self, sheet, sheetinfo, styles):
         # values


### PR DESCRIPTION
To be able to sum them for example. Otherwise they are escaped with `'`.